### PR TITLE
feat: make normalize issue number func return slice

### DIFF
--- a/prow/github/issue_number_test.go
+++ b/prow/github/issue_number_test.go
@@ -123,7 +123,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 		actualNumbers := NormalizeIssueNumbers(tc.content, tc.currOrg, tc.currRepo)
 
 		if !reflect.DeepEqual(tc.expectNumbers, actualNumbers) {
-			t.Errorf("For case \"%s\": \nexpect issue numbers are: \n%v\nbut got: \n%v",
+			t.Errorf("For case \"%s\": \nexpect issue numbers are: \n%+v\nbut got: \n%+v",
 				tc.name, tc.expectNumbers, actualNumbers)
 		}
 	}

--- a/prow/github/issue_number_test.go
+++ b/prow/github/issue_number_test.go
@@ -25,7 +25,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			},
 		},
 		{
-			name:     "issue number with full prefix in the same Repo",
+			name:     "issue number with full prefix in the same repo",
 			content:  "Issue Number: close pingcap/tidb#123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
@@ -35,7 +35,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			},
 		},
 		{
-			name:     "issue number with full prefix in the another Repo",
+			name:     "issue number with full prefix in the another repo",
 			content:  "Issue Number: close pingcap/tiflow#123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
@@ -45,7 +45,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			},
 		},
 		{
-			name:     "issue Number with full prefix in the another Org",
+			name:     "issue number with full prefix in the another Org",
 			content:  "Issue Number: close tikv/tikv#123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
@@ -55,7 +55,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			},
 		},
 		{
-			name:     "issue Number with link prefix in the same Repo",
+			name:     "issue number with link prefix in the same repo",
 			content:  "Issue Number: close https://github.com/pingcap/tidb/issues/123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
@@ -65,7 +65,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			},
 		},
 		{
-			name:     "issue Number with link prefix in the another Repo",
+			name:     "issue number with link prefix in the another repo",
 			content:  "Issue Number: close https://github.com/pingcap/tiflow/issues/123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
@@ -75,7 +75,7 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			},
 		},
 		{
-			name:     "issue Number with link prefix in the another Org",
+			name:     "issue number with link prefix in the another org",
 			content:  "Issue Number: close https://github.com/tikv/tikv/issues/123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",

--- a/prow/github/issue_number_test.go
+++ b/prow/github/issue_number_test.go
@@ -1,18 +1,18 @@
 package github
 
 import (
+	"reflect"
 	"testing"
 )
 
 func TestNormalizeIssueNumbers(t *testing.T) {
 	testcases := []struct {
-		name      string
-		content   string
-		currOrg   string
-		currRepo  string
-		delimiter string
+		name     string
+		content  string
+		currOrg  string
+		currRepo string
 
-		expectNumbers string
+		expectNumbers []IssueNumberData
 	}{
 		{
 			name:     "issue number with short prefix",
@@ -20,55 +20,69 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close #123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 123},
+			},
 		},
 		{
-			name:     "issue number with full prefix in the same repo",
+			name:     "issue number with full prefix in the same Repo",
 			content:  "Issue Number: close pingcap/tidb#123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close #123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 123},
+			},
 		},
 		{
-			name:     "issue number with full prefix in the another repo",
-			content:  "Issue Number: close pingcap/ticdc#123",
+			name:     "issue number with full prefix in the another Repo",
+			content:  "Issue Number: close pingcap/tiflow#123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close pingcap/ticdc#123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tiflow", Number: 123},
+			},
 		},
 		{
-			name:     "issue number with full prefix in the another org",
+			name:     "issue Number with full prefix in the another Org",
 			content:  "Issue Number: close tikv/tikv#123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close tikv/tikv#123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "tikv", Repo: "tikv", Number: 123},
+			},
 		},
 		{
-			name:     "issue number with link prefix in the same repo",
+			name:     "issue Number with link prefix in the same Repo",
 			content:  "Issue Number: close https://github.com/pingcap/tidb/issues/123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close #123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 123},
+			},
 		},
 		{
-			name:     "issue number with link prefix in the another repo",
-			content:  "Issue Number: close https://github.com/pingcap/ticdc/issues/123",
+			name:     "issue Number with link prefix in the another Repo",
+			content:  "Issue Number: close https://github.com/pingcap/tiflow/issues/123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close pingcap/ticdc#123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tiflow", Number: 123},
+			},
 		},
 		{
-			name:     "issue number with link prefix in the another org",
+			name:     "issue Number with link prefix in the another Org",
 			content:  "Issue Number: close https://github.com/tikv/tikv/issues/123",
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close tikv/tikv#123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "tikv", Repo: "tikv", Number: 123},
+			},
 		},
 		{
 			name:     "duplicate issue numbers with same associate prefix",
@@ -76,7 +90,9 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close #123",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 123},
+			},
 		},
 		{
 			name:     "multiple issue numbers with same associate prefix",
@@ -84,33 +100,30 @@ func TestNormalizeIssueNumbers(t *testing.T) {
 			currOrg:  "pingcap",
 			currRepo: "tidb",
 
-			expectNumbers: "close #123, close #456",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 123},
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 456},
+			},
 		},
 		{
-			name:      "multiple issue numbers and custom delimiter",
-			content:   "Issue Number: ref #123, close #456",
-			currOrg:   "pingcap",
-			currRepo:  "tidb",
-			delimiter: "\n",
+			name:     "multiple issue numbers break with newline",
+			content:  "Issue Number: ref #123\nclose #456",
+			currOrg:  "pingcap",
+			currRepo: "tidb",
 
-			expectNumbers: "ref #123\nclose #456",
-		},
-		{
-			name:      "multiple issue numbers and custom delimiter",
-			content:   "Issue Number: ref #123\nclose #456",
-			currOrg:   "pingcap",
-			currRepo:  "tidb",
-			delimiter: "\n",
-
-			expectNumbers: "ref #123\nclose #456",
+			expectNumbers: []IssueNumberData{
+				{AssociatePrefix: "ref", Org: "pingcap", Repo: "tidb", Number: 123},
+				{AssociatePrefix: "close", Org: "pingcap", Repo: "tidb", Number: 456},
+			},
 		},
 	}
 
 	for _, testcase := range testcases {
 		tc := testcase
-		actualNumbers := NormalizeIssueNumbers(tc.content, tc.currOrg, tc.currRepo, tc.delimiter)
-		if tc.expectNumbers != actualNumbers {
-			t.Errorf("For case \"%s\": \nexpect issue numbers are: \n%s\nbut got: \n%s",
+		actualNumbers := NormalizeIssueNumbers(tc.content, tc.currOrg, tc.currRepo)
+
+		if !reflect.DeepEqual(tc.expectNumbers, actualNumbers) {
+			t.Errorf("For case \"%s\": \nexpect issue numbers are: \n%v\nbut got: \n%v",
 				tc.name, tc.expectNumbers, actualNumbers)
 		}
 	}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -785,8 +785,8 @@ func (pr PullRequest) Regexp(str string) *regexp.Regexp {
 
 // NormalizeIssueNumbers is an utils method in CommitTemplate that used to extract the issue numbers in the text
 // and normalize it by a uniform format.
-func (pr PullRequest) NormalizeIssueNumbers(content, currOrg, currRepo, delimiter string) string {
-	return github.NormalizeIssueNumbers(content, currOrg, currRepo, delimiter)
+func (pr PullRequest) NormalizeIssueNumbers(content, currOrg, currRepo string) []github.IssueNumberData {
+	return github.NormalizeIssueNumbers(content, currOrg, currRepo)
 }
 
 // isPassingTests returns whether or not all contexts set on the PR except for

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3515,7 +3515,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 		actual := c.prepareMergeDetails(test.tpl, test.pr, test.mergeMethod)
 
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("Case %s failed: \nexpected:\n%+v\nbut got:\n%+v\n", test.name, test.expected, actual)
+			t.Errorf("Case %s failed: expected %+v, got %+v", test.name, test.expected, actual)
 		}
 	}
 }

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3220,7 +3220,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 		tpl: config.TideMergeCommitTemplate{
 			Title: getTemplate("CommitTitle", "{{ .Title }} (#{{ .Number }})"),
 			Body: getTemplate("CommitBody", `
-				{{- $pattern := .Regexp "(?i)Issue Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*#(?P<issue_number>[1-9]\\d*))+" -}}
+				{{- $pattern := .Regexp "(?im)Issue Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*#(?P<issue_number>[1-9]\\d*))+" -}}
 				{{- $body := print .Body -}}
 				{{- $pattern.FindString $body -}}
 			`),
@@ -3247,7 +3247,11 @@ func TestPrepareMergeDetails(t *testing.T) {
 				{{- $body := print .Body -}}
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
-				{{- .NormalizeIssueNumbers $body $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $body $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3263,7 +3267,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "close #1, close #2, ref #3, ref #4",
+			CommitMessage: "close pingcap/tidb#1, close pingcap/tidb#2, ref pingcap/tidb#3, ref pingcap/tidb#4",
 		},
 	}, {
 		name: "Commit template uses Regexp and NormalizeIssueNumbers function",
@@ -3275,7 +3279,11 @@ func TestPrepareMergeDetails(t *testing.T) {
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
 				{{- $issueNumberLine := $pattern.FindString $body -}}
-				{{- .NormalizeIssueNumbers $issueNumberLine $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3291,7 +3299,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "close #2, ref #3",
+			CommitMessage: "close pingcap/tidb#2, ref pingcap/tidb#3",
 		},
 	}, {
 		name: "Commit template uses NormalizeIssueNumbers to handle issue link",
@@ -3303,7 +3311,11 @@ func TestPrepareMergeDetails(t *testing.T) {
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
 				{{- $issueNumberLine := $pattern.FindString $body -}}
-				{{- .NormalizeIssueNumbers $issueNumberLine $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3319,7 +3331,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "close #2, ref #3",
+			CommitMessage: "close pingcap/tidb#2, ref pingcap/tidb#3",
 		},
 	}, {
 		name: "Commit template uses NormalizeIssueNumbers to handle cross-repository linked issue",
@@ -3331,7 +3343,11 @@ func TestPrepareMergeDetails(t *testing.T) {
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
 				{{- $issueNumberLine := $pattern.FindString $body -}}
-				{{- .NormalizeIssueNumbers $issueNumberLine $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3347,7 +3363,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "close #2, ref tikv/tikv#3",
+			CommitMessage: "close pingcap/tidb#2, ref tikv/tikv#3",
 		},
 	}, {
 		name: "Commit template uses NormalizeIssueNumbers to handle issue number with full prefix",
@@ -3359,7 +3375,11 @@ func TestPrepareMergeDetails(t *testing.T) {
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
 				{{- $issueNumberLine := $pattern.FindString $body -}}
-				{{- .NormalizeIssueNumbers $issueNumberLine $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3375,7 +3395,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "close #2, ref #3",
+			CommitMessage: "close pingcap/tidb#2, ref pingcap/tidb#3",
 		},
 	}, {
 		name: "Commit template uses NormalizeIssueNumbers to handle cross-repository issue number with full prefix",
@@ -3387,7 +3407,11 @@ func TestPrepareMergeDetails(t *testing.T) {
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
 				{{- $issueNumberLine := $pattern.FindString $body -}}
-				{{- .NormalizeIssueNumbers $issueNumberLine $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3403,19 +3427,62 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "close #2, ref tikv/tikv#3",
+			CommitMessage: "close pingcap/tidb#2, ref tikv/tikv#3",
+		},
+	}, {
+		name: "Commit template uses NormalizeIssueNumbers with template shorten issue number prefix",
+		tpl: config.TideMergeCommitTemplate{
+			Title: getTemplate("CommitTitle", "{{ .Title }} (#{{ .Number }})"),
+			Body: getTemplate("CommitBody", `
+				{{- $pattern := .Regexp "(?im)^Issue Number:.+" -}}
+				{{- $body := print .Body -}}
+				{{- $org := print .Repository.Owner.Login -}}
+				{{- $repo := print .Repository.Name -}}
+				{{- $issueNumberLine := $pattern.FindString $body -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+					{{- if $index }}, {{ end -}}
+					{{- /* simplify issue number prefix */ -}}
+					{{- if and (eq .Org $org) (eq .Repo $repo) -}}
+						{{- .AssociatePrefix }} #{{ .Number -}}
+					{{- else -}}
+						{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+					{{- end -}}
+				{{- end -}}
+				{{- " " -}}
+			`),
+		},
+		pr: PullRequest{
+			Number:     githubql.Int(1),
+			Mergeable:  githubql.MergeableStateMergeable,
+			HeadRefOID: githubql.String("SHA"),
+			Repository: repository,
+			Title:      "my commit title",
+			Body:       "\r\nIssue Number: close #1, close pingcap/tidb#2, ref tikv/tikv#3, ref pingcap/tiflow#4\r\n",
+		},
+		mergeMethod: "merge",
+		expected: github.MergeDetails{
+			SHA:           "SHA",
+			MergeMethod:   "merge",
+			CommitTitle:   "my commit title (#1)",
+			CommitMessage: "close #1, close #2, ref tikv/tikv#3, ref pingcap/tiflow#4 ",
 		},
 	}, {
 		name: "Commit template uses NormalizeIssueNumbers to handle unrelated content",
 		tpl: config.TideMergeCommitTemplate{
 			Title: getTemplate("CommitTitle", "{{ .Title }} (#{{ .Number }})"),
 			Body: getTemplate("CommitBody", `
-				{{- $pattern := .Regexp "(?i)Issue Number:.+" -}}
+				{{- $pattern := .Regexp "(?im)^Issue Number:.+" -}}
 				{{- $body := print .Body -}}
 				{{- $org := print .Repository.Owner.Login -}}
 				{{- $repo := print .Repository.Name -}}
 				{{- $issueNumberLine := $pattern.FindString $body -}}
-				{{- .NormalizeIssueNumbers $issueNumberLine $org $repo "" -}}
+				{{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+				{{- range $index, $number := $numbers -}}
+				{{- if $index }}, {{ end -}}
+				{{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+				{{- end -}}
+				{{- " " -}}
 			`),
 		},
 		pr: PullRequest{
@@ -3431,7 +3498,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 			SHA:           "SHA",
 			MergeMethod:   "merge",
 			CommitTitle:   "my commit title (#1)",
-			CommitMessage: "",
+			CommitMessage: " ",
 		},
 	}}
 
@@ -3448,7 +3515,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 		actual := c.prepareMergeDetails(test.tpl, test.pr, test.mergeMethod)
 
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("Case %s failed: expected %+v, got %+v", test.name, test.expected, actual)
+			t.Errorf("Case %s failed: \nexpected:\n%+v\nbut got:\n%+v\n", test.name, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Let users be able to customize the format of issue numbers in the commit template.

The `Normalizeissuenumber` function is responsible for sorting the issue numbers from a small to large according to number, converting to a full lowercase, converting the link into a particular syntax prefix.