### PR TITLE
Feature/lgtm-count-reviewers

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -362,7 +362,7 @@ type Lgtm struct {
 	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
 	// ReviewerCount is the minimum number of approved reviewers.
 	// Defaults 1 reviewers.
-	ReviewerCount *int `json:"request_count,omitempty"`
+	ReviewerCount *int `json:"reviewer_count,omitempty"`
 }
 
 // Jira holds the config for the jira plugin.

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -360,6 +360,9 @@ type Lgtm struct {
 	// StickyLgtmTeam specifies the GitHub team whose members are trusted with sticky LGTM,
 	// which eliminates the need to re-lgtm minor fixes/updates.
 	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
+	// ReviewerCount is the minimum number of approved reviewers.
+	// Defaults 1 reviewers.
+	ReviewerCount *int `json:"request_count,omitempty"`
 }
 
 // Jira holds the config for the jira plugin.

--- a/prow/plugins/lgtm/comment.go
+++ b/prow/plugins/lgtm/comment.go
@@ -1,0 +1,190 @@
+package lgtm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/utils/strings/slices"
+)
+
+// lgtmTimelineNotificationName defines the name used in the title for the lgtm notifications.
+const lgtmTimelineNotificationName = "LGTM Timeline notifier"
+const lgtmTimelineNotificationHeader = "[" + lgtmTimelineNotificationName + "]\n---\nTimeline:\n"
+
+var notificationRegex = regexp.MustCompile(`(?is)^\[` + lgtmTimelineNotificationName + `\] *?([^\n]*)(?:\n[-]{3}\n(.*))?`)
+
+type comment struct {
+	Body        string
+	Author      string
+	CreatedAt   time.Time
+	HTMLURL     string
+	ID          int
+	ReviewState github.ReviewState
+}
+
+func filterComments(comments []*comment, filter func(*comment) bool) []*comment {
+	filtered := make([]*comment, 0, len(comments))
+	for _, c := range comments {
+		if filter(c) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+func getLast(cs []*comment) *comment {
+	if len(cs) == 0 {
+		return nil
+	}
+	return cs[len(cs)-1]
+}
+
+func commentsFromIssueComments(ics []github.IssueComment) []*comment {
+	comments := make([]*comment, 0, len(ics))
+	for i := range ics {
+		comments = append(comments, commentFromIssueComment(&ics[i]))
+	}
+	return comments
+}
+
+func commentFromIssueComment(ic *github.IssueComment) *comment {
+	if ic == nil {
+		return nil
+	}
+	return &comment{
+		Body:      ic.Body,
+		Author:    ic.User.Login,
+		CreatedAt: ic.CreatedAt,
+		HTMLURL:   ic.HTMLURL,
+		ID:        ic.ID,
+	}
+}
+
+func notificationMatcher(isBot func(string) bool) func(*comment) bool {
+	return func(c *comment) bool {
+		if !isBot(c.Author) {
+			return false
+		}
+		match := notificationRegex.FindStringSubmatch(c.Body)
+		return len(match) > 0
+	}
+}
+
+func parseValidLGTMFromTimelines(commentBody string) []string {
+	var ret []string
+
+	for _, line := range strings.Split(commentBody, "\n") {
+		agreed, login := parseLgtmTimelineRecordLine(line)
+		if login == "" {
+			continue
+		}
+
+		if agreed {
+			ret = append(ret, login)
+		} else {
+			// reset when it received a new deny voting.
+			ret = []string{}
+		}
+	}
+
+	return ret
+}
+
+func hasDumpLGTMs(gc githubClient, org, repo string, number int, login string) (bool, error) {
+	comments, err := listTimelineComments(gc, org, repo, number)
+	if err != nil {
+		return false, err
+	}
+
+	comment := getLast(comments)
+	if comment == nil {
+		return false, err
+	}
+	// found the last agreed timeline in timeline comment, then compare it.
+	duplicate := slices.Contains(parseValidLGTMFromTimelines(comment.Body), login)
+
+	return duplicate, nil
+}
+
+func updateTimelineComment(gc githubClient, org, repo string, number int, login string, wantLGTM bool) error {
+	notifications, err := listTimelineComments(gc, org, repo, number)
+	if err != nil {
+		return err
+	}
+	latestNotification := getLast(notifications)
+
+	var messageLines []string
+	if latestNotification == nil {
+		messageLines = append(messageLines, lgtmTimelineNotificationHeader)
+	} else {
+		messageLines = append(messageLines, latestNotification.Body)
+	}
+
+	if wantLGTM {
+		messageLines = append(messageLines, fmt.Sprintf("- `%s`: %s agreed by [%s](https://github.com/%s).",
+			time.Now(), `:ballot_box_with_check:`, login, login))
+	} else {
+		messageLines = append(messageLines, fmt.Sprintf("- `%s`: %s reset by [%s](https://github.com/%s).",
+			time.Now(), `:zero:`, login, login))
+	}
+	newMessage := strings.Join(messageLines, "\n")
+
+	for _, notif := range notifications {
+		if err := gc.DeleteComment(org, repo, notif.ID); err != nil {
+			return err
+		}
+	}
+
+	return gc.CreateComment(org, repo, number, newMessage)
+}
+
+func stringifyLgtmTimelineRecordLine(lgtmTime time.Time, wantLGTM bool, login string) string {
+	tpl := "- `%s`: %s %s by [%s](https://github.com/%s)."
+
+	actionStr := "reset"
+	actionEmoji := ":zero"
+	if wantLGTM {
+		actionStr = "agreed"
+		actionEmoji = `:ballot_box_with_check:`
+	}
+
+	return fmt.Sprintf(tpl, lgtmTime, actionEmoji, actionStr, login, login)
+}
+
+func parseLgtmTimelineRecordLine(line string) (bool, string) {
+	reg := regexp.MustCompile(`^\- .* (agreed|reset) by \[([-_a-zA-Z\d\.]+)\]\(https://github\.com/.*`)
+
+	submatches := reg.FindStringSubmatch(line)
+	if len(submatches) < 2 {
+		return false, ""
+	}
+
+	action := submatches[1]
+	login := submatches[2]
+	switch action {
+	case "agreed":
+		return true, login
+	case "reset":
+		return false, login
+	default:
+		return false, ""
+	}
+}
+
+func listTimelineComments(gc githubClient, org, repo string, number int) ([]*comment, error) {
+	issueComments, err := gc.ListIssueComments(org, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	botUserChecker, err := gc.BotUserChecker()
+	if err != nil {
+		return nil, err
+	}
+
+	commentsFromIssueComments := commentsFromIssueComments(issueComments)
+	return filterComments(commentsFromIssueComments, notificationMatcher(botUserChecker)), nil
+}

--- a/prow/plugins/lgtm/comment_test.go
+++ b/prow/plugins/lgtm/comment_test.go
@@ -1,0 +1,94 @@
+package lgtm
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_parseValidLGTMFromimelines(t *testing.T) {
+	tests := []struct {
+		name        string
+		commentBody string
+		want        []string
+	}{
+		{
+			name:        "no timelines",
+			commentBody: lgtmTimelineNotificationHeader,
+			want:        nil,
+		},
+		{
+			name: "one lgtm timelines",
+			commentBody: strings.Join([]string{
+				lgtmTimelineNotificationHeader,
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user1"),
+			}, "\n"),
+			want: []string{"user1"},
+		},
+		{
+			name: "multi lgtm timelines",
+			commentBody: strings.Join([]string{
+				lgtmTimelineNotificationHeader,
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user1"),
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user2"),
+			}, "\n"),
+			want: []string{"user1", "user2"},
+		},
+		{
+			name: "have a latest reset vote in timelines",
+			commentBody: strings.Join([]string{
+				lgtmTimelineNotificationHeader,
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user1"),
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user2"),
+				stringifyLgtmTimelineRecordLine(time.Now(), false, "user3"),
+			}, "\n"),
+			want: []string{},
+		},
+		{
+			name: "have a previous reset vote in timelines",
+			commentBody: strings.Join([]string{
+				lgtmTimelineNotificationHeader,
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user1"),
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user2"),
+				stringifyLgtmTimelineRecordLine(time.Now(), false, "user3"),
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user4"),
+			}, "\n"),
+			want: []string{"user4"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseValidLGTMFromTimelines(tt.commentBody); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseValidLGTMFromimelines() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseLgtmTimelineRecordLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		want  bool
+		want1 string
+	}{
+		{
+			name:  "lgtm",
+			line:  stringifyLgtmTimelineRecordLine(time.Now(), true, "fakeUser"),
+			want:  true,
+			want1: "fakeUser",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := parseLgtmTimelineRecordLine(tt.line)
+			if got != tt.want {
+				t.Errorf("parseLgtmTimelineRecordLine() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("parseLgtmTimelineRecordLine() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -20,6 +20,7 @@ package lgtm
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -338,16 +339,82 @@ func handle(wantLGTM bool, config *plugins.Configuration, ownersClient repoowner
 		log.Info("Removing LGTM label.")
 		return removeLGTMAndRequestReview(gc, opts, cp, org, repoName, number, getLogins(assignees))
 	} else if !hasLGTM && wantLGTM {
-		log.Info("Adding LGTM label.")
-		return increaseLGTM(gc, opts, cp, log, org, repoName, number, issueAuthor)
+		return increaseLGTM(gc, opts, cp, log, org, repoName, number, issueAuthor, labels)
 	}
 
 	return nil
 }
 
-func increaseLGTM(gc githubClient, opts *plugins.Lgtm, cp commentPruner, log *logrus.Entry, org, repo string, number int, issueAuthor string) error {
+func parseNeedsMoreLgtmCount(opts *plugins.Lgtm, labels []github.Label) (int64, error) {
+	var needMoreLGTMCount int64 = 1
+	if opts.ReviewerCount != nil {
+		needMoreLGTMCount = int64(*opts.ReviewerCount)
+	}
+
+	for _, l := range labels {
+		// execlude not matched labels.
+		matches := LGTMNeedMoreLabelRe.FindStringSubmatch(l.Name)
+		if len(matches) != 2 {
+			continue
+		}
+
+		val, err := strconv.ParseInt(matches[1], 10, 32)
+		if err != nil {
+			return 0, err
+		}
+
+		// update with minimal value because we add the new label then delete the old label.
+		if val >= needMoreLGTMCount {
+			continue
+		}
+		needMoreLGTMCount = val
+	}
+
+	return needMoreLGTMCount, nil
+}
+
+func lgtmLabelNames(labels []github.Label) []string {
+	var labelNames []string
+
+	for _, l := range labels {
+		if LGTMNeedMoreLabelRe.MatchString(l.Name) {
+			labelNames = append(labelNames, l.Name)
+		}
+
+	}
+	return labelNames
+}
+
+func increaseLGTM(gc githubClient, opts *plugins.Lgtm, cp commentPruner, log *logrus.Entry, org, repo string, number int, issueAuthor string, labels []github.Label) error {
+	needMoreLGTMCount, err := parseNeedsMoreLgtmCount(opts, labels)
+	if err != nil {
+		return err
+	}
+
+	toRemoveLabels := lgtmLabelNames((labels))
+
+	if needMoreLGTMCount > 1 {
+		newNeedsMoreLabel := fmt.Sprintf("needs-%d-more-lgtm", needMoreLGTMCount-1)
+		if err := gc.AddLabel(org, repo, number, newNeedsMoreLabel); err != nil {
+			return err
+		}
+		for _, toRemoveLabel := range toRemoveLabels {
+			if err := gc.RemoveLabel(org, repo, number, toRemoveLabel); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// lgtm approved count >= required count.
+	log.Info("Adding LGTM label.")
 	if err := gc.AddLabel(org, repo, number, LGTMLabel); err != nil {
 		return err
+	}
+	for _, toRemoveLabel := range toRemoveLabels {
+		if err := gc.RemoveLabel(org, repo, number, toRemoveLabel); err != nil {
+			return err
+		}
 	}
 
 	if !stickyLgtm(log, gc, opts, issueAuthor, org) {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -46,7 +46,8 @@ var (
 	// LGTMLabel is the name of the lgtm label applied by the lgtm plugin
 	LGTMLabel = labels.LGTM
 	// LGTMRe is the regex that matches lgtm comments
-	LGTMRe = regexp.MustCompile(`(?mi)^/lgtm(?: no-issue)?\s*$`)
+	LGTMRe              = regexp.MustCompile(`(?mi)^/lgtm(?: no-issue)?\s*$`)
+	LGTMNeedMoreLabelRe = regexp.MustCompile(`(?i)^needs-(\d+)-more-lgtm$`)
 	// LGTMCancelRe is the regex that matches lgtm cancel comments
 	LGTMCancelRe        = regexp.MustCompile(`(?mi)^/(remove-lgtm|lgtm cancel)\s*$`)
 	removeLGTMLabelNoti = "New changes are detected. LGTM label has been removed."

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -488,9 +488,9 @@ func TestLGTMComment(t *testing.T) {
 			} else if isLGTMLabelAdded(fc.IssueLabelsAdded, "org", "repo", 5, tc.hasLGTM) {
 				t.Error("should not have added LGTM.")
 			}
-			if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+			if tc.shouldComment && len(execludeTimelineType(fc.IssueComments[5])) != 1 {
 				t.Error("should have commented.")
-			} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+			} else if !tc.shouldComment && len(execludeTimelineType(fc.IssueComments[5])) != 0 {
 				t.Error("should not have commented.")
 			}
 			if tc.shouldRequest && len(fc.ReviewersRequested) == 0 {
@@ -852,9 +852,9 @@ func TestLGTMFromApproveReview(t *testing.T) {
 		} else if isLGTMLabelAdded(fc.IssueLabelsAdded, "org", "repo", 5, tc.hasLGTM) {
 			t.Errorf("For case %s, should not have added LGTM.", tc.name)
 		}
-		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+		if tc.shouldComment && len(execludeTimelineType(fc.IssueComments[5])) != 1 {
 			t.Errorf("For case %s, should have commented.", tc.name)
-		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+		} else if !tc.shouldComment && len(execludeTimelineType(fc.IssueComments[5])) != 0 {
 			t.Errorf("For case %s, should not have commented.", tc.name)
 		}
 	}
@@ -1452,4 +1452,16 @@ func isLGTMLabelAdded(issueLabelsAdded []string, owner, repo string, number int,
 		return len(issueLabelsAdded) > 1 && slices.Contains(issueLabelsAdded, lgtmLabel)
 	}
 	return len(issueLabelsAdded) > 0 && slices.Contains(issueLabelsAdded, lgtmLabel)
+}
+
+func execludeTimelineType(comments []github.IssueComment) []github.IssueComment {
+	var ret []github.IssueComment
+
+	for _, c := range comments {
+		if !strings.Contains(c.Body, lgtmTimelineNotificationHeader) {
+			ret = append(ret, c)
+		}
+	}
+
+	return ret
 }


### PR DESCRIPTION
- The plugin will add `lgtm` label in the pull request when at least `ReviewerCount` people agreed with `/lgtm` or review approves.
- Any valid reviewer againsted, it will reset the accumulated votes and remove the `lgtm` label if existed, the againsted vote will not be accumulated in the next lgtm voting.

## TODO 

- [x] fix dup `lgtm` comment or review approves from same reviewer.
- [x] comment when some body delete his `/lgtm` or `/lgtm cancel` comments for auditing.
Signed-off-by: wuhuizuo <wuhuizuo@126.com>