### PR TITLE
fix(prow/plugins/lgtm): fix dup lgtm judging

### DIFF
--- a/prow/plugins/lgtm/comment.go
+++ b/prow/plugins/lgtm/comment.go
@@ -148,7 +148,7 @@ func stringifyLgtmTimelineRecordLine(lgtmTime time.Time, wantLGTM bool, login st
 }
 
 func parseLgtmTimelineRecordLine(line string) (bool, string) {
-	reg := regexp.MustCompile(`^\- .* (agreed|reset) by \[([-_a-zA-Z\d\.]+)\]\(https://github\.com/.*`)
+	reg := regexp.MustCompile(`^\- .* (agreed|reset) by \[([-_a-zA-Z\d\.]+(\[bot\])?)\]\(https://github\.com/.*`)
 
 	submatches := reg.FindStringSubmatch(line)
 	if len(submatches) < 2 {

--- a/prow/plugins/lgtm/comment_test.go
+++ b/prow/plugins/lgtm/comment_test.go
@@ -56,6 +56,16 @@ func Test_parseValidLGTMFromimelines(t *testing.T) {
 			}, "\n"),
 			want: []string{"user4"},
 		},
+		{
+			name: "reset by bot app",
+			commentBody: strings.Join([]string{
+				lgtmTimelineNotificationHeader,
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user1"),
+				stringifyLgtmTimelineRecordLine(time.Now(), true, "user2"),
+				stringifyLgtmTimelineRecordLine(time.Now(), false, "fake-bot[bot]"),
+			}, "\n"),
+			want: []string{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -361,8 +361,13 @@ func handle(wantLGTM bool, config *plugins.Configuration, ownersClient repoowner
 		return updateTimelineComment(gc, rc.repo.Owner.Login, rc.repo.Name, rc.number, rc.author, false)
 	} else if !hasLGTM && wantLGTM {
 		dup, err := hasDumpLGTMs(gc, org, repoName, number, author)
-		if err != nil || dup {
+		if err != nil {
 			return err
+		}
+		if dup {
+			return gc.CreateComment(org, repoName, number, plugins.FormatResponseRaw(
+				rc.body, rc.htmlURL, rc.author, "Your lgtm message is repeated, so it is ignored.",
+			))
 		}
 
 		return increaseLGTM(gc, opts, &rc, cp, log, labels)


### PR DESCRIPTION
## Why

`lgtm` plugin's dup judging logic was not consider Github app bot name, it will be `<name>[bot]` , but common user's login can not be this format.