### PR TITLE
Fix/tide-merge-template-function-NormalizeIssueNumbers

### DIFF
--- a/prow/github/issue_number.go
+++ b/prow/github/issue_number.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	issueNumberBlockRegexpTemplate  = "(?i)%s?\\s*%s(?P<issue_number>[1-9]\\d*)"
+	issueNumberBlockRegexpTemplate  = "(?i)%s\\s+%s(?P<issue_number>[1-9]\\d*)"
 	associatePrefixRegexp           = "(?P<associate_prefix>ref|close[sd]?|resolve[sd]?|fix(e[sd])?)"
 	orgRegexp                       = "[a-zA-Z0-9][a-zA-Z0-9-]{0,38}"
 	repoRegexp                      = "[a-zA-Z0-9-_]{1,100}"

--- a/prow/github/issue_number_bug.dat
+++ b/prow/github/issue_number_bug.dat
@@ -1,0 +1,46 @@
+<!--
+Thank you for contributing to TiKV! 
+
+If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document. 
+
+If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
+
+PR Title Format:
+1. module [, module2, module3]: what's changed
+2. *: what's changed
+-->
+
+### What is changed and how it works?
+<!--
+
+Please create an issue first to describe the problem.
+
+There MUST be one line starting with "Issue Number:  " and 
+linking the relevant issues via the "close" or "ref".
+
+For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
+
+-->
+Issue Number: Ref #14570
+
+......
+some other data with "#"
+#12
+#13
+......
+
+### Related changes
+
+- Need to cherry-pick to the release branch
+
+### Check List <!--REMOVE the items that are not applicable-->
+
+Tests <!-- At least one of them must be included. -->
+
+- Integration test
+
+### Release note <!-- bugfixes or new feature need a release note -->
+
+```release-note
+None
+```

--- a/prow/github/issue_number_test.go
+++ b/prow/github/issue_number_test.go
@@ -1,0 +1,40 @@
+package github
+
+import (
+	_ "embed"
+	"reflect"
+	"testing"
+)
+
+//go:embed issue_number_bug.dat
+var content string
+
+func TestNormalizeIssueNumbers(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		currOrg  string
+		currRepo string
+		want     []IssueNumberData
+	}{
+		{
+			name:     "xxx",
+			content:  content,
+			currOrg:  "tikv",
+			currRepo: "tikv",
+			want: []IssueNumberData{{
+				AssociatePrefix: "ref",
+				Org:             "tikv",
+				Repo:            "tikv",
+				Number:          14570,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeIssueNumbers(tt.content, tt.currOrg, tt.currRepo); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NormalizeIssueNumbers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ignore these formats:

- `#1334`
- `abc #123`
- `abc#124`
- `abc#https://org/repo/issue/1234`
- `abc#https://org/repo/issue/1234`

include those formats:
- `Fix #123`
- `ref org/repo#1234`
- `close https://github.com/org/repo/issue/1234`

Fix https://github.com/ti-community-infra/tichi/issues/1175