### PR TITLE
fix(prow/plugins/lgtm): fix lgtm plugin when only sub dir changes and no parent inherit

### DIFF
--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -332,7 +332,8 @@ func handle(wantLGTM bool, config *plugins.Configuration, ownersClient repoowner
 		if err != nil {
 			return err
 		}
-		if !loadReviewers(ro, filenames).Has(github.NormLogin(author)) {
+		if !loadReviewers(ro, filenames).Has(github.NormLogin(author)) &&
+			!ro.TopLevelApprovers().Has(github.NormLogin(author)) {
 			resp := "adding LGTM is restricted to approvers and reviewers in OWNERS files."
 			log.Infof("Reply to /lgtm request with comment: \"%s\"", resp)
 			return gc.CreateComment(org, repoName, number, plugins.FormatResponseRaw(body, htmlURL, author, resp))


### PR DESCRIPTION
In this case, reviewers only include sub dir's approvers and reviewers and parent level reviewers but not include approvers in parent folder.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>